### PR TITLE
Doublons dans la BDD

### DIFF
--- a/srr/check.php
+++ b/srr/check.php
@@ -17,6 +17,12 @@
             $simple->init();
             $simple->handle_content_type();
             foreach($simple->get_items() as $item){
+                
+                // If there is already an article with the same name in the BDD, break();
+                $already_exist = $sqlite->query('SELECT count(*) AS nb_article FROM items WHERE title = '.$sqlite->quote($item->get_title()));
+                $already_exist = $already_exist->fetch();
+                if(intval($already_exist['nb_article']) > 0) break 1;
+                
                 $maxid = $sqlite->query('SELECT max(id) FROM items');
                 $maxid = $maxid->fetch();
                 $maxid = $maxid[0] + 1;


### PR DESCRIPTION
Afin d'éviter les doublons d'articles, et de se retrouver avec des articles plus anciens dans la BDD, que l'on aurait déjà lu, on vérifie si le titre de l'article n'est pas déjà dans la BDD.

Le système est assez simple (ex. si on a déjà lu un article récent, vu qu'il n'est plus dans la BDD il va réapparaître).
Mais c'est déjà mieux. :)
