### PR TITLE
Ajout des fichiers import/export.

### DIFF
--- a/srr/parametres/export.php
+++ b/srr/parametres/export.php
@@ -1,0 +1,44 @@
+<?php 
+session_start();
+header('Content-type: text/xml');
+header('Content-Disposition: attachment; filename="feeds_opml_srr.xml"');
+
+/* SimplePie Init & Config */
+include '../include/simplepie.inc';
+$simplePie = new SimplePie();
+$simplePie->set_useragent('Mozilla/4.0 '.SIMPLEPIE_USERAGENT.' (with Simple RSS Reader)');
+$simplePie->enable_cache(false);
+
+/* SQLite3 */
+$sqlite = new PDO('sqlite:../include/data.db');
+$query = $sqlite->query('SELECT id,url,title FROM feeds WHERE user_id="' . $_SESSION['id'] . '"');
+
+/* OPML Header & Footer */
+$head = <<<OPML
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="1.0">
+	<head>
+		<title>Mes flux</title>
+	</head>
+	<body>
+OPML;
+$foot = '</body></opml>';
+
+// TODO :
+// Stocker les feeds_urls dans la bdd, car si il y a énormément de flux, le process peut être très long
+/* Fetch feeds */
+$feeds = '';
+while($feed = $query->fetch()){
+	//print_r($feed);
+	$simplePie->set_feed_url($feed['url']);
+	$simplePie->init();
+	$simplePie->handle_content_type();
+	$feeds .= '		<outline text="'.htmlspecialchars($feed['title']).'" title="'.htmlspecialchars($feed['title']).'" type="rss" xmlUrl="'.$simplePie->subscribe_url().'" htmlUrl="'.$feed['url'].'"/>';
+	$feeds .= '
+'; 
+}
+
+echo $head;
+echo $feeds;
+echo $foot;
+?>

--- a/srr/parametres/feeds.php
+++ b/srr/parametres/feeds.php
@@ -17,7 +17,8 @@
         $sqlite->query('INSERT INTO feeds VALUES(' . $maxid . ',' . $sqlite->quote($_GET['title']) . ',' . $sqlite->quote($_GET['url']) . ',' . $sqlite->quote(time()) . ',"' . $_SESSION['id'] . '")');   
     }
     elseif(isset($_GET['del']) && is_numeric($_GET['del'])){
-        $sqlite->query('DELETE FROM feeds WHERE id="' . $_GET['del'] . '"');    
+        $sqlite->query('DELETE FROM feeds WHERE id="' . $_GET['del'] . '"');
+        $sqlite->query('DELETE FROM items WHERE feed_id="'.$_GET['del'].'"');
     }
     header('Location: index.php');
 ?>

--- a/srr/parametres/import.php
+++ b/srr/parametres/import.php
@@ -40,8 +40,8 @@ else:
 					$maxid = $sqlite->query('SELECT max(id) FROM feeds');
 					$maxid = $maxid->fetch();
 					$maxid = $maxid[0] + 1;
-					$maxid = $sqlite->quote($maxid);
-					$title = $sqlite->quote($flux['title']);
+					$maxid = $sqlite->quote($maxid); 
+					$title = (empty($flux['title'])) ? $sqlite->quote($flux['text']) : $sqlite->quote($flux['title']);
 					$url = $sqlite->quote($flux['htmlUrl']);
 			
 			
@@ -63,7 +63,7 @@ else:
 				$maxid = $maxid->fetch();
 				$maxid = $maxid[0] + 1;
 				$maxid = $sqlite->quote($maxid);
-				$title = $sqlite->quote($entry['title']);
+				$title = (empty($entry['title'])) ? $sqlite->quote($entry['text']) : $sqlite->quote($entry['title']);
 				$url = $sqlite->quote($entry['htmlUrl']);
 			
 			

--- a/srr/parametres/import.php
+++ b/srr/parametres/import.php
@@ -1,0 +1,83 @@
+<?php
+session_start();
+ini_set('display_errors','On');
+error_reporting(0);
+
+/* XML File */
+$xml = file_get_contents($_FILES['file']['tmp_name']);
+$file = simplexml_load_string($xml);
+
+/* SQLite3 */
+$sqlite = new PDO('sqlite:../include/data.db'); ?>
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Paramètres</title>
+        <link type="text/css" rel="stylesheet" href="../themes/<?php echo $_SESSION['theme']; ?>/params.css" />
+        <meta http-equiv=Content-Type content="text/html; charset=utf-8" />
+    </head>
+    <body>
+
+		<article><h1>Paramètres (<a href="../connexion/disconnect.php">déconnexion</a>)</h1><hr /><fieldset>
+<?php
+if(!$file):
+	echo '<p>Erreur lors de l\'import, le fichier est probablement invalide.<br/>';
+	echo '<a href="./">Retour</a></p>';
+
+else:
+
+	foreach($file->body->outline as $entry):
+		if(empty($entry['htmlUrl'])):
+			foreach($entry as $flux):
+			
+				// If there is already an feed with the same url in the BDD
+				$already_exist = $sqlite->query('SELECT count(*) AS nb_sites FROM feeds WHERE user_id = '.$sqlite->quote($_SESSION['id']).' AND url = '.$sqlite->quote($flux['htmlUrl']));
+				$already_exist = $already_exist->fetch();
+		
+				if(intval($already_exist['nb_sites']) == 0):
+		
+					$maxid = $sqlite->query('SELECT max(id) FROM feeds');
+					$maxid = $maxid->fetch();
+					$maxid = $maxid[0] + 1;
+					$maxid = $sqlite->quote($maxid);
+					$title = $sqlite->quote($flux['title']);
+					$url = $sqlite->quote($flux['htmlUrl']);
+			
+			
+					$sqlite->query('INSERT INTO feeds VALUES('.$maxid.', '.$title.', '.$url.', "0", '.$sqlite->quote($_SESSION['id']).')');
+			
+				endif;	
+
+			
+			endforeach;
+		
+		else:
+			// If there is already an feed with the same url in the BDD
+			$already_exist = $sqlite->query('SELECT count(*) AS nb_sites FROM feeds WHERE user_id = '.$sqlite->quote($_SESSION['id']).' AND url = '.$sqlite->quote($entry['htmlUrl']));
+			$already_exist = $already_exist->fetch();
+		
+			if(intval($already_exist['nb_sites']) == 0):
+		
+				$maxid = $sqlite->query('SELECT max(id) FROM feeds');
+				$maxid = $maxid->fetch();
+				$maxid = $maxid[0] + 1;
+				$maxid = $sqlite->quote($maxid);
+				$title = $sqlite->quote($entry['title']);
+				$url = $sqlite->quote($entry['htmlUrl']);
+			
+			
+				$sqlite->query('INSERT INTO feeds VALUES('.$maxid.', '.$title.', '.$url.', "0", '.$sqlite->quote($_SESSION['id']).')');
+			
+			endif;	
+		endif;
+	endforeach;
+	
+	echo '<p>L\'importation a bien été effectuée.<br/>';
+	echo '<a href="./">Retour</a></p>';
+	
+endif;
+?>
+		</fieldset></article>		
+	</body>
+</html>


### PR DESCRIPTION
C'est bon, c'est fonctionnel.
Le script d'import nécessite la lib SimpleXML (regarde dans le phpinfo();) pour parser le fichier.
Le fichier qui est importé doit être valide OPML. J'ai essayé d'importer des fichiers venant de Google Reader et d'autres logiciels passé par des amis : ça marche.

Dans le script d'export, si on a beaucoup de flux, le processus peut être long. Je suppose qu'il faudrait rajouter un champs dans la BDD avec l'url direct du flux. Cela permettrait de créer le fichier OPML plus rapidement, et dans le cas de l'update des feeds (avec check.php), ça pourrait aussi accélérer (plus besoin d'aller chercher l'url du flux avec une requête cURL).
